### PR TITLE
Hook destroyPages() to fastify onClose

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uyamazak/fastify-hc-pages",
   "description": "A Fastify plugin that allows you to use Headless Chrome Pages with Puppeteer",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "author": "uyamazak",
   "access": "public",
   "bugs": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,10 @@ export const plugin = async (
   fastify.decorate('destroyPages', async () => {
     await hcPages.destroy()
   })
+  fastify.addHook('onClose', async (instance, done) => {
+    await instance.destroyPages()
+    done()
+  })
   next()
 }
 

--- a/test/hc-pages.test.ts
+++ b/test/hc-pages.test.ts
@@ -17,7 +17,6 @@ async function build(t) {
     })
     reply.send(result)
   })
-  t.tearDown(async () => await server.destroyPages())
   t.tearDown(server.close.bind(server))
   return server
 }


### PR DESCRIPTION
destroyPages(), which used to need to be executed explicitly by user, is now executed with a hook.