### PR TITLE
Devide pagesNum from pageOptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uyamazak/fastify-hc-pages",
   "description": "A Fastify plugin that allows you to use Headless Chrome Pages with Puppeteer",
-  "version": "0.4.0",
+  "version": "1.0.0",
   "author": "uyamazak",
   "access": "public",
   "bugs": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,8 +15,8 @@ export const plugin = async (
   options: HcPagesOptions,
   next: (err?: Error) => void
 ): Promise<void> => {
-  const { pageOptions, launchOptions } = options
-  const hcPages = await HCPages.init(pageOptions, launchOptions)
+  const { pagesNum, pageOptions, launchOptions } = options
+  const hcPages = await HCPages.init(pagesNum, pageOptions, launchOptions)
   fastify.decorate(
     'runOnPage',
     async (callback: RunOnPageCallback<unknown>) => {

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -1,0 +1,72 @@
+import { test } from 'tap'
+import fastify from 'fastify'
+import { Page } from 'puppeteer'
+import { InjectOptions } from 'light-my-request'
+import { hcPages } from '../src/index'
+
+const titleString = 'this is a test title'
+const contentHtml = `<html><head><title>${titleString}</title></head><body></body></html>`
+
+/**
+ *   pagesNum: number
+  userAgent: string
+  pageTimeoutMilliseconds: number
+  emulateMediaTypeScreenEnabled: boolean
+  acceptLanguage: string
+  viewport?: Viewport
+  */
+async function build(t) {
+  const server = fastify()
+  server.register(hcPages)
+  server.get('/gettitle', async (_, reply) => {
+    const result = await server.runOnPage<string>(async (page: Page) => {
+      await page.setContent(contentHtml, { waitUntil: 'domcontentloaded' })
+      return await page.title()
+    })
+    reply.send(result)
+  })
+  t.tearDown(server.close.bind(server))
+  return server
+}
+
+test('set pageNum 5', async (t) => {
+  const server = fastify()
+  const options = { pagesNum: 5 }
+  await server.register(hcPages, options)
+  t.tearDown(server.close.bind(server))
+})
+
+test('set pageTimeoutMilliseconds', async (t) => {
+  const server = fastify()
+  const options = { pageOptions: { pageTimeoutMilliseconds: 30000 } }
+  await server.register(hcPages, options)
+  t.tearDown(server.close.bind(server))
+})
+
+test('set userAgent', async (t) => {
+  const server = fastify()
+  const options = { pageOptions: { userAgent: 'testUserAgentString' } }
+  await server.register(hcPages, options)
+  t.tearDown(server.close.bind(server))
+})
+
+test('set emulateMediaTypeScreenEnabled', async (t) => {
+  const server = fastify()
+  const options = { pageOptions: { emulateMediaTypeScreenEnabled: true } }
+  await server.register(hcPages, options)
+  t.tearDown(server.close.bind(server))
+})
+
+test('set acceptLanguage', async (t) => {
+  const server = fastify()
+  const options = { pageOptions: { acceptLanguage: 'ja' } }
+  await server.register(hcPages, options)
+  t.tearDown(server.close.bind(server))
+})
+
+test('set viewport', async (t) => {
+  const server = fastify()
+  const options = { pageOptions: { viewport: { width: 1920, height: 1080 } } }
+  await server.register(hcPages, options)
+  t.tearDown(server.close.bind(server))
+})

--- a/types/hc-pages.ts
+++ b/types/hc-pages.ts
@@ -1,12 +1,12 @@
 import { BrowserLaunchArgumentOptions, Viewport, Page } from 'puppeteer'
 
 export interface HcPagesOptions {
-  pageOptions?: PageOptions
+  pagesNum?: number
+  pageOptions?: Partial<PageOptions>
   launchOptions?: BrowserLaunchArgumentOptions
 }
 
 export interface PageOptions {
-  pagesNum: number
   userAgent: string
   pageTimeoutMilliseconds: number
   emulateMediaTypeScreenEnabled: boolean


### PR DESCRIPTION
Because `pagesNum` is not a setting of Puppeteer's pages, 
but a setting of this plugin, I separated it as a single argument.

Major version change due to change in the way options are passed.

Added a test to set and pass each option.