### PR TITLE
Fix Broken runOnPage callback failed.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uyamazak/fastify-hc-pages",
   "description": "A Fastify plugin that allows you to use Headless Chrome Pages with Puppeteer",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "author": "uyamazak",
   "access": "public",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "scripts": {
     "build": "rm -rf ./dist && tsc",
     "prepublishOnly": "npm run build",
+    "postinstall": "npm run build",
     "test": "tap --ts --no-check-coverage --no-browser --timeout=60 test/**/*.test.ts",
     "lint": "eslint --fix ./ --ext ts"
   },

--- a/src/hc-pages.ts
+++ b/src/hc-pages.ts
@@ -65,9 +65,17 @@ export class HCPages {
     page: Page,
     callback: RunOnPageCallback<T>
   ): Promise<T> {
-    const result = await callback(page)
-    this.readyPages.push(page)
-    return result
+    try {
+      const result = await callback(page)
+      this.readyPages.push(page)
+      return result
+    } catch (e) {
+      console.error(e)
+      await page.close()
+      const newPage = await this.createPage()
+      this.readyPages.push(newPage)
+      throw e
+    }
   }
 
   public async runOnPage<T>(callback: RunOnPageCallback<T>): Promise<T> {
@@ -85,11 +93,16 @@ export class HCPages {
     return result
   }
 
+  private async createPage(): Promise<Page> {
+    const page = await this.browser.newPage()
+    await this.applyPageConfigs(page)
+    return page
+  }
+
   private async createPages(): Promise<Page[]> {
     const pages = []
     for (let i = 0; i < this.pagesNum; i++) {
-      const page = await this.browser.newPage()
-      await this.applyPageConfigs(page)
+      const page = await this.createPage()
       console.log(`page number ${i} is created`)
       pages.push(page)
     }

--- a/src/hc-pages.ts
+++ b/src/hc-pages.ts
@@ -71,9 +71,7 @@ export class HCPages {
       return result
     } catch (e) {
       console.error(e)
-      await page.close()
-      const newPage = await this.createPage()
-      this.readyPages.push(newPage)
+      this.readyPages.push(page)
       throw e
     }
   }

--- a/test/rejected.test.ts
+++ b/test/rejected.test.ts
@@ -1,0 +1,55 @@
+import { test } from 'tap'
+import fastify from 'fastify'
+import { Page } from 'puppeteer'
+import { InjectOptions, Response } from 'light-my-request'
+import { hcPages } from '../src/index'
+
+const titleString = 'this is a test title'
+const contentHtml = `<html><head><title>${titleString}</title></head><body></body></html>`
+
+interface Test {
+  teardown(cb: unknown): unknown
+}
+
+async function build(t: Test) {
+  const server = fastify()
+  server.register(hcPages)
+  server.get('/rejected', async (_, reply) => {
+    const result = await server.runOnPage(async () => {
+      throw Error('rejected')
+    })
+    reply.send(result)
+  })
+  server.get('/success', async (_, reply) => {
+    const result = await server.runOnPage<string>(async (page: Page) => {
+      await page.setContent(contentHtml, { waitUntil: 'domcontentloaded' })
+      return await page.title()
+    })
+    reply.send(result)
+  })
+  t.teardown(server.close.bind(server))
+  return server
+}
+
+test('runOnPage success after many rejected', async (t) => {
+  const server = await build(t)
+  const rejectPromises: Promise<Response>[] = []
+  for (let i = 0; i < 10; i++) {
+    rejectPromises.push(
+      server.inject({
+        method: 'GET',
+        url: '/rejected',
+      } as InjectOptions)
+    )
+  }
+  const rejectResults = await Promise.all(rejectPromises)
+  for (const re of rejectResults) {
+    console.log(re.payload)
+    t.equal(re.statusCode, 500)
+  }
+  const res = await server.inject({
+    method: 'GET',
+    url: '/success',
+  } as InjectOptions)
+  t.equal(res.statusCode, 200)
+})


### PR DESCRIPTION
If runOnPage callback failed (e.g. Timeout), the process of pusing the Page to the standby array would skip, and it would not work properly.
It is now returned to the standby array even when it fails.

fix https://github.com/uyamazak/hc-pdf-server/discussions/450