### PR TITLE
Remove postinstall for install failed

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   "scripts": {
     "build": "rm -rf ./dist && tsc",
     "prepublishOnly": "npm run build",
-    "postinstall": "npm run build",
     "test": "tap --ts --no-check-coverage --no-browser --timeout=60 test/**/*.test.ts",
     "lint": "eslint --fix ./ --ext ts"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uyamazak/fastify-hc-pages",
   "description": "A Fastify plugin that allows you to use Headless Chrome Pages with Puppeteer",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "author": "uyamazak",
   "access": "public",
   "bugs": {


### PR DESCRIPTION
I forgot to delete the one I added during testing, 

and it caused an error when I installed it from npm, so I removed it. 

https://github.com/uyamazak/fastify-hc-pages/pull/211