### PR TITLE
Fix error behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uyamazak/fastify-hc-pages",
   "description": "A Fastify plugin that allows you to use Headless Chrome Pages with Puppeteer",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "author": "uyamazak",
   "access": "public",
   "bugs": {

--- a/src/hc-pages.ts
+++ b/src/hc-pages.ts
@@ -67,12 +67,12 @@ export class HCPages {
   ): Promise<T> {
     try {
       const result = await callback(page)
-      this.readyPages.push(page)
       return result
     } catch (e) {
       console.error(e)
-      this.readyPages.push(page)
       throw e
+    } finally {
+      this.readyPages.push(page)
     }
   }
 
@@ -85,10 +85,14 @@ export class HCPages {
 
     const promise = this.runCallback(page, callback)
     this.currentPromises.push(promise)
-    const result = await promise
-    this.currentPromises.splice(this.currentPromises.indexOf(promise), 1)
-
-    return result
+    try {
+      return await promise
+    } catch (e) {
+      console.error(e)
+      throw e
+    } finally {
+      this.currentPromises.splice(this.currentPromises.indexOf(promise), 1)
+    }
   }
 
   private async createPage(): Promise<Page> {


### PR DESCRIPTION
Page array processings (push and remove) were being skipped when an error occurred, so it run in finally.