### PR TITLE
Remove callback for fp

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uyamazak/fastify-hc-pages",
   "description": "A Fastify plugin that allows you to use Headless Chrome Pages with Puppeteer",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": "uyamazak",
   "access": "public",
   "bugs": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,11 +13,9 @@ declare module 'fastify' {
 export const plugin = async (
   fastify: FastifyInstance,
   options: HcPagesOptions,
-  next: (err?: Error) => void
 ): Promise<void> => {
   const { pagesNum, pageOptions, launchOptions } = options
   const hcPages = await HCPages.init(pagesNum, pageOptions, launchOptions)
-
   fastify.decorate(
     'runOnPage',
     async (callback: RunOnPageCallback<unknown>) => {
@@ -31,7 +29,6 @@ export const plugin = async (
     await instance.destroyPages()
     done()
   })
-  next()
 }
 
 export const hcPages = fp(plugin, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ declare module 'fastify' {
 export const plugin = async (
   fastify: FastifyInstance,
   options: HcPagesOptions,
-  done: (err?: Error) => void
+  next: (err?: Error) => void
 ): Promise<void> => {
   const { pagesNum, pageOptions, launchOptions } = options
   const hcPages = await HCPages.init(pagesNum, pageOptions, launchOptions)
@@ -31,7 +31,7 @@ export const plugin = async (
     await instance.destroyPages()
     done()
   })
-  done()
+  next()
 }
 
 export const hcPages = fp(plugin, {


### PR DESCRIPTION
https://github.com/uyamazak/fastify-hc-pages/pull/506

The docker build succeeds on Mac M1, but when I do a run, I get the following error.

https://github.com/uyamazak/hc-pdf-server/issues/796

```
/app/node_modules/avvio/plugin.js:122
      const err = new AVV_ERR_READY_TIMEOUT(name)
                  ^
AvvioError [Error]: Plugin did not start in time: 'hc-pages-plugin'. You may have forgotten to call 'done' function or to resolve a Promise
    at Timeout._onTimeout (/app/node_modules/avvio/plugin.js:122:19)
    at listOnTimeout (node:internal/timers:569:17)
    at process.processTimers (node:internal/timers:512:7) {
  code: 'AVV_ERR_READY_TIMEOUT',
  fn: <ref *1> [AsyncFunction: plugin] {
    default: [Circular *1],
    hcPagesPlugin: [Circular *1],
    [Symbol(skip-override)]: true,
    [Symbol(fastify.display-name)]: 'hc-pages-plugin',
    [Symbol(plugin-meta)]: { fastify: '^4.0.0', name: 'hc-pages-plugin' }
  }
}

Node.js v18.15.0
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
Remove the callback to match the asynchronous way of doing things in the documentation.

https://www.npmjs.com/package/fastify-plugin
![image](https://user-images.githubusercontent.com/22805530/229983846-da01ab2a-fddc-4eeb-ba61-ecb94b880c0e.png)

